### PR TITLE
Wrap README prose at 120 columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Secvault
 
-Rails secrets.yml functionality for Rails 7.2+. Secvault restores the classic Rails secrets.yml functionality that was removed in Rails 7.2, allowing you to manage secrets using the familiar YAML-based approach.
+Rails secrets.yml functionality for Rails 7.2+. Secvault restores the classic Rails secrets.yml functionality that was
+removed in Rails 7.2, allowing you to manage secrets using the familiar YAML-based approach.
 
 [![Gem Version](https://img.shields.io/gem/v/secvault.svg)](https://rubygems.org/gems/secvault)
 [![CI](https://github.com/unnitallman/secvault/actions/workflows/ci.yml/badge.svg)](https://github.com/unnitallman/secvault/actions/workflows/ci.yml)


### PR DESCRIPTION
Wraps prose in `README.md` at 120 columns so it stops scrolling
horizontally in editors without soft wrap.

Only paragraph text is rewrapped. Code blocks, tables, headings, URLs and
HTML are left byte for byte alone, and the rendered output is unchanged.

Opened by `gh-repo-compliancy`.
